### PR TITLE
CASMCMS-8093 - update python constraint for broken dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-8093 - fix the python dependencies.
+- CASMCMS-7970 - update dev.cray.com server addresses.
 
 ## [2.7.0] - 2022-06-28
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ An example of using this container (as an `initContainer`) is provided below.
 
 ```
       initContainers:
-      - image: dtr.dev.cray.com:443/cray/ims-utils:1.1.2
+      - image: artifactory.algol60.net/csm-docker/stable/cray-ims-utils:2.7.0
         name: fetch-recipe
         env:
         - name: API_GATEWAY_HOSTNAME

--- a/constraints.txt
+++ b/constraints.txt
@@ -10,6 +10,7 @@ ims-python-helper==2.9.0
 Jinja2==2.10.1
 jmespath==0.9.4
 kubernetes==11.0.0
+MarkupSafe<2.1.0
 oauthlib==2.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Only use Cray-procured packages
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 --trusted-host artifactory.algol60.net
 -c constraints.txt


### PR DESCRIPTION
## Summary and Scope

The version of Jinja2 that we use is not pinned to the version of MarkupSafe that we use.  When a newer version of MarkupSafe was released it did not follow correct semver practices and released a version that broke Jinja2.  This pins MarkupSafe to a version that works correctly with the version of Jinja2 that we want to include.

At the same time, this fixes the dev.cray.com addresses that will be retired shortly. 

## Issues and Related PRs
* Resolves [CASMCMS-8093](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8093)
* Resolves [CASMCMS-7970](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7970)

## Testing
### Tested on:

  * Build system

### Test description:

This will be tested in its entirety when the services that use this image are tested before they are released.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

