### PR TITLE
CASMCMS-8316 - add retry to file download in fetch.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.9.0] - 2022-09-28
+## [2.9.1] - 2022-11-09
+### Changed
+- CASMCMS-8316 - Added a retry to the file download so it doesn't fail once and quit.
 
+## [2.9.0] - 2022-09-28
 ### Changed
 - CASMTRIAGE-4268 - Increased the s3 file download chunk size for better performance.
 


### PR DESCRIPTION
## Summary and Scope

There are times where the file download fails the first time due to intermittent network issues. This is related to CASMTRIAGE-4504. This change adds a retry loop so one http failure doesn't torpedo the entire ims job.

## Issues and Related PRs
* Resolves [CASMCMS-8316](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8316)

## Testing
### Tested on:
  * `Shandy`

### Test description:

This image is used by the ims service when a customize or create job is created. I uploaded the new version of the image to shandy and modified the ims configuration to use the test image for new jobs. I was then able to start new jobs with debug parameters where the fine download was performed in an infinite loop. We could see where the initial download failed and it had to try multiple times to succeed. Other times it succeeded on the first attempt.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N - not a helm service
- Was downgrade tested? If not, why? N - not a helm service
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a very low risk change as it only introduces a retry loop in the existing code.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

