### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
+## [Unreleased]
+### Added
+- Authenticate to CSM's artifactory
 
-[1.0.0] - (no date)
+## [1.0.0] - (no date)

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ ENV VIRTUAL_ENV=/scripts/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN pip3 install --upgrade pip && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    pip3 install --upgrade pip && \
     pip3 install \
       --no-cache-dir \
       -r requirements.txt

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -40,6 +40,7 @@ pipeline {
         NAME = "cray-ims-utils"
         DESCRIPTION = "Cray image management service utility docker image"
         IS_STABLE = getBuildIsStable()
+	DOCKER_BUILDKIT = "1"
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@
 NAME ?= cray-ims-utils
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
 
+ifneq ($(wildcard ${HOME}/.netrc),)
+        DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
+
 all: runbuildprep lint image
 
 runbuildprep:


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.


## Issues and Related PRs


* Resolves CASMINST-5443

## Testing


### Tested on:

  * Build environment

### Test description:

It builds successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

