### PR TITLE
CASMTRIAGE-4784 - preserve file permissions when applying recipe templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [2.9.4] - 2023-01-11
+### Changed
+- CASMTRIAGE-4784 - Preserve file permissions when applying recipe templates.
+
 ## [2.9.3] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile
-
-## [Unreleased]
 
 ## [2.9.2] - 2022-12-02
 ### Added

--- a/scripts/fetch.py
+++ b/scripts/fetch.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -391,7 +391,8 @@ class FetchRecipe(FetchBase):
                     with tempfile.NamedTemporaryFile("w", delete=False) as outf:
                         outf.write(template.render(**template_values))
 
-                    # remove the original file replace with the templated version
+                    # remove the original file replace with the templated version - preserve the permissions
+                    shutil.copymode(absolute_file_name, outf.name)
                     os.remove(absolute_file_name)
                     shutil.move(outf.name, absolute_file_name)
             except KeyError as keyerror:


### PR DESCRIPTION
## Summary and Scope

When templates are applied to recipe files, it creates a new temporary file with the template values applied, then removes the original file, then moves the new file into the old files location. This was losing the permission flags on the original file. For shell scripts, it lost the 'execute' flag so the script was no longer able to run.

The fix is to just copy the original file permission flags to the new new file before the file switch happens.

## Issues and Related PRs
* Resolves [CASMTRIAGE-4784](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4784)

## Testing
### Tested on:
  * `beau`

### Test description:

I installed the new ims-utils image on beau and modified the recipe build config map to use the new image. I was able to create a new image from the original cos recipe, then run a new customize job on the resulting image. This new image had all the missing zypper repos from the recipe - confirming the templatized 'add-repos' shell script executed successfully with the new image in place.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk as this just copies file attributes in a templatized recipe file.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

