### PR TITLE
CASMCMS-8368 - add arm64 support for image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- CASMCMS-8368 - add an arm64 image to the build
+
 ## [2.9.3] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile
-
-## [Unreleased]
 
 ## [2.9.2] - 2022-12-02
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,13 +23,14 @@
 #
 # Cray Image Management Service image build environment utilities Dockerfile
 #
+
 FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
 
 # Add utilities that are required for this command
 WORKDIR /
 COPY requirements.txt constraints.txt /
 RUN apk add --upgrade --no-cache apk-tools \
-		&& apk update \
+        && apk update \
         && apk add --update --no-cache \
             curl \
             rpm \

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -40,7 +40,7 @@ pipeline {
         NAME = "cray-ims-utils"
         DESCRIPTION = "Cray image management service utility docker image"
         IS_STABLE = getBuildIsStable()
-	DOCKER_BUILDKIT = "1"
+        DOCKER_BUILDKIT = "1"
     }
 
     stages {
@@ -90,7 +90,7 @@ pipeline {
             }
 
             steps {
-                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE)
+                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE, multiArch: true)
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,7 +28,7 @@ NAME ?= cray-ims-utils
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
 
 ifneq ($(wildcard ${HOME}/.netrc),)
-        DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+		DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
 endif
 
 all: runbuildprep lint image
@@ -40,4 +40,7 @@ lint:
 		./cms_meta_tools/scripts/runLint.sh
 
 image:
-		docker build --pull ${DOCKER_ARGS} --tag '${NAME}:${DOCKER_VERSION}' .
+		docker buildx create --use
+		docker buildx build --platform=linux/amd64,linux/arm64 --pull ${DOCKER_ARGS} .
+		docker buildx build --platform=linux/amd64 --load --tag '${NAME}:${DOCKER_VERSION}' .
+		docker buildx build --platform=linux/arm64 --load --tag '${NAME}:${DOCKER_VERSION}-arm64' .


### PR DESCRIPTION
## Summary and Scope

This changes the build pipeline to produce both arm64 and x86 versions of the docker image. This is required to support the arm64 based image building.

## Issues and Related PRs
* Resolves [CASMCMS-8368](https://github.com/Cray-HPE/ims-utils/compare/CASMCMS-8368)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I examined the produced manifest file for the image and it lists both linux/arm64 and linux/amd64 based images. I then installed the image on Surtur and ran customization jobs to insure the image works in existing x86 image jobs. The testing for the arm64 side will have to wait until we have the qemu emulator set up.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as there is no code changes and the new arm64 image is not used anywhere. The existing workflows were tested and verified to not be impacted by this change.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

