### PR TITLE
CASMCMS-8365 - tweaks to build arm64 recipes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.1] - 2023-05-16
+### Changed
+- CASMCMS-8365 - tweaks to get arm64 recipe building
+
 ## [2.10.0] - 2023-05-03
 ### Added
 - CASMCMS-8368 - add an arm64 image to the build

--- a/scripts/build_ca_rpm.py
+++ b/scripts/build_ca_rpm.py
@@ -32,10 +32,8 @@ import subprocess
 RPM_NAME = "cray_ca_cert"
 RPM_VERSION = "1.0.1"
 
-# set up the target architecture for the rpm build
-RPM_ARCHITECTURE = "x86_64"
-if os.environ['BUILD_ARCH'] == 'aarch64':
-    RPM_ARCHITECTURE = "arm64"
+# There is nothing arch specific in here so build accordingly
+RPM_ARCHITECTURE = "noarch"
 
 ETC_CRAY_CA_DIR = "etc/cray/ca"
 CERTIFICATE_AUTHORITY_NAME = "certificate_authority.crt"

--- a/scripts/package_and_upload.sh
+++ b/scripts/package_and_upload.sh
@@ -38,13 +38,28 @@ set -x
 
 source /scripts/helper.sh
 
+# default kernel file name is different for aarch64 but allow override from existing
+# KERNEL_FILENAME param
+BUILD_ARCH=${BUILD_ARCH:-x86_64}
+case "$BUILD_ARCH" in
+  "aarch64") KERNEL_DEFAULT="Image" ;;
+  *) KERNEL_DEFAULT="vmlinuz" ;;
+esac
+KERNEL_FILENAME=${KERNEL_FILENAME:-${KERNEL_DEFAULT}}
+
+# HACK: the craycli will always create a default value of 'vmlinuz' regardless of
+#  aarch rather than allow 'no default' to pass through if the user does not enter
+#  anything. Override at this point and fix in Jira CASMCMS-8624.
+if [ "$BUILD_ARCH" = "aarch64" -a "$KERNEL_FILENAME" = "vmlinuz" ]; then
+  echo "Incorrect default kernel filename for aarch64 - defaulting to Image"
+  KERNEL_FILENAME="Image"
+fi
+
 IMS_PYTHON_HELPER_TIMEOUT=${IMS_PYTHON_HELPER_TIMEOUT:-720}
 IMAGE_ROOT_PARENT=${IMAGE_ROOT_PARENT:-/mnt/image}
 IMAGE_ROOT_DIR=${IMAGE_ROOT_DIR:-/mnt/image/build/image-root/}
-KERNEL_FILENAME=${KERNEL_FILENAME:-vmlinuz}
 INITRD_FILENAME=${INITRD_FILENAME:-initrd}
 IMAGE_ROOT_ARCHIVE_NAME=${IMAGE_ROOT_ARCHIVE_NAME:-$KIWI_RECIPE_NAME}
-BUILD_ARCH=${BUILD_ARCH:-x86_64}
 
 # Set ims job status
 set_job_status "packaging_artifacts"


### PR DESCRIPTION
## Summary and Scope

In order for the arm64 recipes to successfully complete, there were a couple more tweaks needed:
1) Build and package the cert rpm as 'noarch' so it can be used for both arm64 and x86.
2) Use the correct default kernel file name depending on the arch being built.

## Issues and Related PRs
* Resolves [CASMCMS-8365](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8365)

## Testing
### Tested on:
  * `Mug`

### Test description:

Deployed the test image on Mug and ran a recipe build - it succeeded.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is lower risk.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

