### PR TITLE
CASMINST-6450 - pin versions for csm-1.3.4 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.5] - 2023-06-06
+- CASMINST-6450 - Pin versions for csm-1.3.4 release.
+
 ## [2.9.4] - 2023-01-11
 ### Changed
 - CASMTRIAGE-4784 - Preserve file permissions when applying recipe templates.

--- a/constraints.txt
+++ b/constraints.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 docutils==0.14
 google-auth==1.6.1
 idna==2.8
-ims-python-helper>=2.9.0
+ims-python-helper==2.10.2
 Jinja2==2.10.1
 jmespath==0.9.4
 kubernetes==11.0.0


### PR DESCRIPTION
## Summary and Scope

The csm-1.3.4 release picked up some new (incompatible) changes from the latest ims-python-helper. This pins the release of ims-python-helper that should be used so each compile will not update that version. 


## Issues and Related PRs
* Resolves [CASMINST-6450](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6450)

## Testing
### Tested on:
  * `Fanta`

### Test description:

I verified the 1.3.4 upgrade was not working correctly, then updated the version of ims-utils being used to this one, and re-tested and all works as it should.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change, as it just pins the version of ims-python-helper to what was being used when the release originally went out.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

