### PR TITLE
CASMCMS-8708 - fix image build to include build job metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.3] - 2023-07-11
+### Changed
+- CASMCMS-8708 - fix build to include metadata needed for nightly rebuilds.
+
 ## [2.10.2] - 2023-06-05
 ### Changed
 - CASM-4232: Require at least version 2.14.0 of `ims-python-helper` in order to get associated logging enhancements.

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -79,8 +79,11 @@ pipeline {
             }
 
             steps {
-                echo "Docker args are ${env.DOCKER_ARGS}"
-                sh "make image"
+                withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-publish', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                    echo "Docker args are ${env.DOCKER_ARGS}"
+                    sh "echo \$ARTIFACTORY_PASSWORD | docker login artifactory.algol60.net --username \$ARTIFACTORY_USERNAME --password-stdin"
+                    sh "make image"
+                }
             }
         }
 
@@ -90,7 +93,7 @@ pipeline {
             }
 
             steps {
-                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE, multiArch: true)
+                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE, push: false)
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@
 
 NAME ?= cray-ims-utils
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
+ifeq ($(IS_STABLE),true)
+	DOCKER_NAME ?= artifactory.algol60.net/csm-docker/stable/$(NAME)
+else
+	DOCKER_NAME ?= artifactory.algol60.net/csm-docker/unstable/$(NAME)
+endif
 
 ifneq ($(wildcard ${HOME}/.netrc),)
 		DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
@@ -40,6 +45,10 @@ lint:
 		./cms_meta_tools/scripts/runLint.sh
 
 image:
+		# NOTE: add ',linux/arm64' to the platform arg to also build arm64 image
 		docker buildx create --use
-		docker buildx build --platform=linux/amd64,linux/arm64 --pull ${DOCKER_ARGS} .
-		docker buildx build --platform=linux/amd64 --load --tag '${NAME}:${DOCKER_VERSION}' .
+		docker buildx build --push --platform=linux/amd64 ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${DOCKER_VERSION}' .
+
+image_local:
+		docker buildx create --use
+		docker buildx build --load ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${DOCKER_VERSION}' .


### PR DESCRIPTION
## Summary and Scope

Remove the arm64 image builds as it is not needed right now, but leave the main framework in place (use docker buildx) in case we need to add that back in soon.

The main problem with the current way of building the image is that the build metadata needed for the nightly rebuilds is not currently included in the image. This resolves that issue and cleans up not needing the arm64 version.

## Issues and Related PRs
* Resolves [CASMCMS-8708](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8708)

## Testing

Tested through the Jenkins build pipeline and just copied from Mikhail's work in ims-kiwi-ng repo.

## Risks and Mitigations

Low risk - just changes to the build pipeline.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
