### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.9.6] - 2023-07-18
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
 
 ## [2.9.5] - 2023-06-06
 - CASMINST-6450 - Pin versions for csm-1.3.4 release.

--- a/constraints.txt
+++ b/constraints.txt
@@ -15,7 +15,7 @@ oauthlib==2.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.2
 python-dateutil==2.8.1
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.23.0
 requests-oauthlib==1.0.0
 rsa==4.7


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/ims-utils/pull/60 to allow support/2.9 branch to be buildable