### PR TITLE
CASMCMS-8801 - switch to using PVC for image mount.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds
+- CASMCMS-8801 - changed the image volume mounts to ude PVC's instead of ephemeral storage.
 
 ### Dependencies
 - CASMCMS-8656: Use `update_external_version` to get latest `ims-python-helper` Python module

--- a/README.md
+++ b/README.md
@@ -55,15 +55,13 @@ An example of using this container (as an `initContainer`) is provided below.
         - configMapRef:
             name: cray-ims-$id-configmap
         volumeMounts:
-        - name: recipe-vol
-          mountPath: /mnt/recipe
         - name: ca-pubkey
           mountPath: /etc/cray/ca
           readOnly: true
         - name: admin-client-auth
           mountPath: '/etc/admin-client-auth'
           readOnly: true
-        command: [ "sh", "-ce", "/scripts/fetch-recipe.sh /mnt/recipe $download_url" ]
+        command: [ "sh", "-ce", "/scripts/fetch-recipe.sh /mnt/image/recipe $download_url" ]
 ```
 
 ## Deployment

--- a/scripts/fetch-recipe.sh
+++ b/scripts/fetch-recipe.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 #
 # Prepares the build environment used for creating an image root.
 #   Usage:
-#     /scripts/fetch-recipe.sh /mnt/recipe http://example.com/path/to/recipe.tgz
+#     /scripts/fetch-recipe.sh /mnt/image/recipe http://example.com/path/to/recipe.tgz
 
 source /scripts/helper.sh
 python3 /scripts/fetch.py --recipe "$@"

--- a/scripts/fetch.py
+++ b/scripts/fetch.py
@@ -214,6 +214,9 @@ class FetchBase(object):
             filename : The filename where the file is to be stored
         """
 
+        # insure the parent dirs exist
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        
         # allow multiple failures while tring to download file
         LOGGER.info("Saving file as '%s'", filename)
         numAttempts=0


### PR DESCRIPTION
## Summary and Scope

There is a limited amount of ephemeral storage on the k8s cluster. We were seeing cases where IMS jobs were failing due to insufficient resources. In order to resolve this, I switched the primary image and recipe mounts in the IMS jobs to use PVC's for volume mounts instead of the ephemeral storage they were using.

## Issues and Related PRs
* Resolves [CASMCMS-8801](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8801)
* Change will also be needed in ims and ims-kiwi-builder repos.

## Testing
### Tested on:
  * `Mug`

### Test description:

I did a helm install/upgrade/downgrade. I ran all the dkms and non/dkms recipe build and customization permutations. They all performed as expected. There is a change to the job data record (to keep track of the PVC created for the job) and I did upgrade/downgrade testing.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a rather large fundamental change, but there is no other way to ease the pressure on the ephemeral storage resources.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

