### PR TITLE
CASMCMS-8821 - Add remote build customize job options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8821 - add support for remote build jobs.
 
 ## [2.11.0] - 2023-09-15
 ### Changed

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -21,47 +21,25 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Cray Image Management Service image build environment utilities Dockerfile
-#
 
-FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
+# Dockerfile for IMS remote customization jobs
 
-# Add utilities that are required for this command
-WORKDIR /
-COPY requirements.txt constraints.txt /
-RUN apk add --upgrade --no-cache apk-tools \
-        && apk update \
-        && apk add --update --no-cache \
-            curl \
-            rpm \
-            squashfs-tools \
-            tar \
-            python3 \
-            py3-pip \
-            gcc \
-            python3-dev \
-            libc-dev \
-            podman \
-            openssh \
-        && apk -U upgrade --no-cache \
-        &&  rm -rf \
-           /var/cache/apk/* \
-           /root/.cache \
-           /tmp/* \
-        && mkdir -p \
-           /scripts \
-           /config
+# Start with the ims-sshd image as it will have most of the tools needed
+FROM registry.local/$IMS_SSHD_IMAGE as base
 
-ENV VIRTUAL_ENV=/scripts/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY /scripts/remote_customize_entrypoint.sh /entrypoint.sh
+COPY /etc/cray/ca/certificate_authority.crt /etc/cray/ca/certificate_authority.crt
+COPY /etc/admin-client-auth /etc/admin-client-auth
+COPY /mnt/image/image.sqsh /data/
+COPY /config/sshd_config /etc/cray/ims/sshd_config
+COPY /root/.ssh/id_ecdsa.pub /etc/cray/ims/authorized_keys
 
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    pip3 install --upgrade pip && \
-    pip3 install \
-      --no-cache-dir \
-      -r requirements.txt
+# Copy in env vars needed for the remote job run
+ENV OAUTH_CONFIG_DIR=$OAUTH_CONFIG_DIR
+ENV BUILD_ARCH=$BUILD_ARCH
+ENV IMS_JOB_ID=$IMS_JOB_ID
+ENV IMAGE_ROOT_PARENT=$IMAGE_ROOT_PARENT
+ENV SSH_JAIL=$SSH_JAIL
+ENV JOB_ENABLE_DKMS=$JOB_ENABLE_DKMS
 
-COPY scripts/* /scripts/
-COPY config/* /config/
-COPY Dockerfile.remote /Dockerfile.remote
+ENTRYPOINT ["/entrypoint.sh"]

--- a/config/sshd_config
+++ b/config/sshd_config
@@ -7,4 +7,3 @@ AuthorizedKeysFile    /etc/cray/ims/authorized_keys
 PasswordAuthentication no
 ChallengeResponseAuthentication no
 Subsystem sftp internal-sftp
-

--- a/constraints.txt
+++ b/constraints.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 docutils==0.14
 google-auth==1.6.3
 idna==2.8
-ims-python-helper==2.15.0
+ims-python-helper==2.16.0
 Jinja2==2.10.3
 jmespath==0.9.5
 kubernetes==11.0.0

--- a/scripts/fetch.py
+++ b/scripts/fetch.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,12 @@
 # Author: Eric Cozzi
 
 import argparse
+import logging
+import os
 from ims_python_helper.fetch import FetchImage, FetchRecipe
+
+LOGGER = logging.getLogger(__file__)
+logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
 
 def main():
     """
@@ -35,6 +40,7 @@ def main():
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--recipe', action='store_true')
     group.add_argument('--image', action='store_true')
+    parser.add_argument('unpack')
     parser.add_argument('path')
     parser.add_argument('url')
     args = parser.parse_args()
@@ -42,7 +48,8 @@ def main():
     if args.recipe:
         FetchRecipe(args.path, args.url).run()
     elif args.image:
-        FetchImage(args.path, args.url).run()
+        b_unpack = args.unpack.lower() in ['true', '1', 't', 'y']
+        FetchImage(args.path, args.url).run(b_unpack)
 
 if __name__ == "__main__":
     main()

--- a/scripts/prep-env.sh
+++ b/scripts/prep-env.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env sh
+#!/bin/sh
 #
 # MIT License
 #
-# (C) Copyright 2018-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,76 @@
 #   Usage:
 #     /scripts/prep-env.sh /mnt/image http://example.com/path/to/image.sqsh
 
+set -x
 source /scripts/helper.sh
-python3 /scripts/fetch.py --image "$@"
+
+function prep_remote_build() {
+    # prepare the ssh keys to access the remote node
+    mkdir -p ~/.ssh
+    cp /etc/cray/remote-keys/id_ecdsa ~/.ssh
+    chmod 600 ~/.ssh/id_ecdsa
+    ssh-keygen -y -f ~/.ssh/id_ecdsa > ~/.ssh/id_ecdsa.pub
+
+    echo "Configuring remote job on host: $REMOTE_BUILD_NODE"
+
+    # the presence of this dir will serve as notification there is a job underway on this remote node 
+    ssh -o StrictHostKeyChecking=no root@${REMOTE_BUILD_NODE} "mkdir -p /tmp/ims_${IMS_JOB_ID}/"
+
+    # Make Cray's CA certificate a trusted system certificate within the container
+    # This will not install the CA certificate into the kiwi imageroot.
+    echo "setting up certs..."
+    CA_CERT='/etc/cray/ca/certificate_authority.crt'
+    if [[ -e $CA_CERT ]]; then
+      cp $CA_CERT  /usr/local/share/ca-certificates
+    else
+      echo "The CA certificate file: $CA_CERT is missing"
+      exit 1
+    fi
+    update-ca-certificates
+    RC=$?
+    if [[ ! $RC ]]; then
+      echo "update-ca-certificates exited with return code: $RC"
+      exit 1
+    fi
+
+    # Apply env vars to dockerfile template
+    (echo "cat <<EOF" ; cat Dockerfile.remote ; echo EOF ) | sh > Dockerfile
+
+    # build the docker image
+    podman build -t ims-remote-${IMS_JOB_ID}:1.0.0 .
+    RC=$?
+    if [[ ! $RC ]]; then
+      echo "Remote image build failed with error code: $RC"
+      exit 1
+    fi
+
+    # Copy docker image to remote node
+    podman save ims-remote-${IMS_JOB_ID}:1.0.0 | ssh -o StrictHostKeyChecking=no root@${REMOTE_BUILD_NODE} podman load
+    RC=$?
+    if [[ ! $RC ]]; then
+      echo "Copying image to remote node failed"
+      exit 1
+    fi
+
+    # start the image on the remote node
+    # NOTE: this will just run indefinately until a complete flag is created
+    # TODO: for now hard-coded to port 2022 - this only allows ONE customize job per node
+    #          - must add code to look for an open port (ie run podman port -a, parse results)
+    ssh -o StrictHostKeyChecking=no root@${REMOTE_BUILD_NODE} "podman run -p 2022:22 --name ims-${IMS_JOB_ID} --privileged --detach ims-remote-${IMS_JOB_ID}:1.0.0"
+}
+
+# configure for remote build
+if [[ -z "${REMOTE_BUILD_NODE}" ]]; then
+  UNPACK="True"
+else
+  UNPACK="False"
+fi
+
+# fetch the image from S3 - unpack if local job
+python3 /scripts/fetch.py --image "$UNPACK" "$@"
 fail_if_error "Downloading image"
+
+# if this is a remote job set up the remote server
+if [[ -n "${REMOTE_BUILD_NODE}" ]]; then
+  prep_remote_build
+fi

--- a/scripts/remote_customize_entrypoint.sh
+++ b/scripts/remote_customize_entrypoint.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+#
+# MIT License
+#
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Entrypoint script for remote customize image job
+# NOTE: this is run from WITHIN the docker image running on the remote build node.
+set -x
+echo on
+
+# Let the root dirs be overridden by arguments to the script
+IMAGE_ROOT_PARENT=${2:-$IMAGE_ROOT_PARENT}
+IMAGE_ROOT_DIR=${IMAGE_ROOT_DIR:-${IMAGE_ROOT_PARENT}/image-root/}
+
+# set up file locations
+SIGNAL_FILE_REMOTE_EXITING=$IMAGE_ROOT_PARENT/remote_exiting
+
+SSH_CONFIG_FILE=/etc/cray/ims/sshd_config
+
+# check the contents of the imported env vars
+echo "Checking env vars"
+IMPORTED_VALS=('OAUTH_CONFIG_DIR' 'BUILD_ARCH' 'IMS_JOB_ID' 'IMAGE_ROOT_PARENT')
+for item in "${IMPORTED_VALS[@]}"; do
+  if [[ -z "${!item}" ]]; then
+    echo ERROR: $item not set in env.sh
+    exit 1
+  fi
+done
+
+# Set up location of complete flag files depending on if this is a jailed env
+## NOTE: there are 2 possible file locations going on here.
+#  If this is a jailed env, then the user signal files will be in the /tmp dir of the jailed env
+#  If this is not a jailed env, then the signal files will be in $IMAGE_ROOT_PARENT
+#  The IMS pod will be looking in $IMAGE_ROOT_PARENT, so a jailed env will need to transfer
+#   the signal files to the correct location
+SIGNAL_FILE_COMPLETE=$IMAGE_ROOT_PARENT/complete
+SIGNAL_FILE_FAILED=$IMAGE_ROOT_PARENT/failed
+USER_SIGNAL_FILE_COMPLETE=$IMAGE_ROOT_PARENT/complete
+USER_SIGNAL_FILE_FAILED=$IMAGE_ROOT_PARENT/failed
+if [ "$SSH_JAIL" = "True" ]; then
+  USER_SIGNAL_FILE_COMPLETE=$IMAGE_ROOT_DIR/tmp/complete
+  USER_SIGNAL_FILE_FAILED=$IMAGE_ROOT_DIR/tmp/failed
+fi
+
+# Make Cray's CA certificate a trusted system certificate within the container
+# This will not install the CA certificate into the kiwi imageroot.
+echo "setting up certs..."
+CA_CERT='/etc/cray/ca/certificate_authority.crt'
+if [[ -e $CA_CERT ]]; then
+  cp $CA_CERT  /usr/share/pki/trust/anchors/.
+else
+  echo "The CA certificate file: $CA_CERT is missing"
+  exit 1
+fi
+update-ca-certificates
+RC=$?
+if [[ ! $RC ]]; then
+  echo "update-ca-certificates exited with return code: $RC"
+  exit 1
+fi
+
+# unpack the image file
+mkdir -p $IMAGE_ROOT_PARENT
+unsquashfs -f -d $IMAGE_ROOT_DIR /data/image.sqsh
+
+# Configure the sshd_config file for jailed chroot dir if needed
+if [ "$SSH_JAIL" = "True" ]; then
+  echo "ChrootDirectory $IMAGE_ROOT_DIR" >> $SSH_CONFIG_FILE
+fi
+
+# set up keys for ssh access
+mkdir -p ~/.ssh
+ssh-keygen -A
+
+# add env vars the incomming users need
+echo "SetEnv IMS_JOB_ID=$IMS_JOB_ID IMS_ARCH=$BUILD_ARCH IMS_DKMS_ENABLED=$JOB_ENABLE_DKMS" >> $SSH_CONFIG_FILE
+
+# Start the SSH server daemon
+/usr/sbin/sshd -E /etc/cray/ims/sshd.log -f $SSH_CONFIG_FILE
+
+# don't spam the log with waiting on user
+set +x
+echo off
+echo "Waiting for signal file"
+
+# Wait for the user to signal they are done
+until [ -f "$USER_SIGNAL_FILE_COMPLETE" ] || [ -f "$USER_SIGNAL_FILE_FAILED" ]
+do
+  sleep 5;
+done
+
+# enable logging for the final packaging
+set -x
+echo on
+
+# if successful, package up the results into a squashfs file to transfer back to worker node
+if [ ! -f "$USER_SIGNAL_FILE_FAILED" ]; then
+  # Remove the successful signal file and put failed flag in place in case squash fails
+  # NOTE: the sshd entrypoint script will be waiting for $SIGNAL_FILE_REMOTE_EXITING
+  rm $SIGNAL_FILE_COMPLETE
+  touch $SIGNAL_FILE_FAILED
+
+  # Make the squashfs formatted archive to transfer results back to job
+  time mksquashfs "$IMAGE_ROOT_DIR" "$IMAGE_ROOT_PARENT/transfer.sqsh"
+  RC=$?
+
+  # handle if the squash fails
+  if [[ ! $RC ]]; then
+    # Already marked as error - just exit
+    echo "ERROR: Squashfs reported an error."
+  else
+    # success, so remove failed flag and add success flag file
+    rm $SIGNAL_FILE_FAILED
+    touch $SIGNAL_FILE_COMPLETE
+  fi
+fi
+
+# Signal that this is finished
+touch $SIGNAL_FILE_REMOTE_EXITING
+
+exit 0


### PR DESCRIPTION
## Summary and Scope

This adds support for remote customize IMS jobs. It works in conjunction with changes in ims and ims-utils to set up, use, and tear down a remote job.

## Issues and Related PRs

* Resolves [CASMCMS-8821](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8821)

## Testing
### Tested on:
  * `Mug`

### Test description:

Installed the new version of ims, ims-utils, and ims-sshd and ran remote and local jobs with and without ssh jails. All work as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Same risk as the rest of this project.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

