### PR TITLE
CASMCMS-8914: Use appropriate version of Python k8s client for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- Bump `kubernetes` from 11.0.0 to 22.6.0 to match CSM 1.6 Kubernetes version
+
 ## [2.11.0] - 2023-09-15
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/constraints.txt
+++ b/constraints.txt
@@ -9,7 +9,8 @@ idna==2.8
 ims-python-helper==0.0.0-imspython
 Jinja2==2.10.3
 jmespath==0.9.5
-kubernetes==11.0.0
+# CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
+kubernetes==22.6.0
 MarkupSafe<2.1.0
 oauthlib==2.1.0
 pyasn1==0.4.8


### PR DESCRIPTION
I noticed that some of our Python code for CSM 1.6 is pulling in non-optimal versions of the Kubernetes client library. Ideally the major version of the library should correspond to the Kubernetes version on the system, but in many cases it is not. This doesn't guarantee that there will be problems, but it's least risky to use the appropriate version.

This problem also exists in past CSM versions, but this is not the kind of thing worth backporting without additional reason, so I'll just confine my change to CSM 1.6.
