### PR TITLE
CASMCMS-8897 - changes for aarch64 remote build node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CASMCMS-8821 - add support for remote build jobs.
 - CASMCMS-8818 - ssh key injection into jobs.
+- CASMCMS-8897 - changes for aarch64 remote build.
 
 ## [2.11.0] - 2023-09-15
 ### Changed

--- a/scripts/prep-env.sh
+++ b/scripts/prep-env.sh
@@ -38,6 +38,12 @@ function prep_remote_build() {
 
     echo "Configuring remote job on host: $REMOTE_BUILD_NODE"
 
+    # set the arch on this job
+    PODMAN_ARCH="linux/amd64"
+    if [ "$BUILD_ARCH" == "aarch64" ]; then
+        PODMAN_ARCH="linux/arm64"
+    fi
+
     # the presence of this dir will serve as notification there is a job underway on this remote node 
     ssh -o StrictHostKeyChecking=no root@${REMOTE_BUILD_NODE} "mkdir -p /tmp/ims_${IMS_JOB_ID}/"
 
@@ -62,7 +68,7 @@ function prep_remote_build() {
     (echo "cat <<EOF" ; cat Dockerfile.remote ; echo EOF ) | sh > Dockerfile
 
     # build the docker image
-    podman build -t ims-remote-${IMS_JOB_ID}:1.0.0 .
+    podman build --platform ${PODMAN_ARCH} -t ims-remote-${IMS_JOB_ID}:1.0.0 .
     RC=$?
     if [[ ! $RC ]]; then
       echo "Remote image build failed with error code: $RC"


### PR DESCRIPTION
## Summary and Scope

Add options to the build of the remote image to target the correct arch of the remote node.

## Issues and Related PRs
* Resolves [CASMCMS-8897](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8897)

## Testing
### Tested on:
  * `Baldar`

### Test description:

Installed the new binary on the machine and set up a blanca peak node as the remote build node. This change was required to build the correct image to run on the remote build node.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Minor risk compared to the entire project.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

