### PR TITLE
CASMCMS-8895 - allow multiple concurrent remote customize jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8821 - add support for remote build jobs.
 - CASMCMS-8818 - ssh key injection into jobs.
 - CASMCMS-8897 - changes for aarch64 remote build.
+- CASMCMS-8895 - allow multiple concurrent remote customize jobs.
 
 ## [2.11.0] - 2023-09-15
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apk add --upgrade --no-cache apk-tools \
             libc-dev \
             podman \
             openssh \
+            bash \
         && apk -U upgrade --no-cache \
         &&  rm -rf \
            /var/cache/apk/* \


### PR DESCRIPTION
## Summary and Scope

Change the scripts to look for an unused port on the remote build node and start / connect to the remote container using that available port. This allows multiple jobs to run instead of having a single hard-coded port that is used.

## Issues and Related PRs
* Resolves [CASMCMS-8895](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8895)

## Testing
### Tested on:
  * `Tyr`

### Test description:

I updated the version of the images being used to the test image and ran through multiple scenarios of kicking off many remote customize jobs in rapid succession. In the logs I verified it always correctly sorted out finding an available port with no unhandled collisions.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No riskier than anything else here...

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

