### PR TITLE
CASMCMS-8923 - update python-helper version and add traps to bash script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8818 - ssh key injection into jobs.
 - CASMCMS-8897 - changes for aarch64 remote build.
 - CASMCMS-8895 - allow multiple concurrent remote customize jobs.
+- CASMCMS-8923 - better cleanup on unexpected exit.
 
 ## [2.12.0] - 2024-02-22
 ### Dependencies

--- a/scripts/remote_customize_entrypoint.sh
+++ b/scripts/remote_customize_entrypoint.sh
@@ -159,6 +159,9 @@ set +x
 echo off
 echo "Waiting for signal file"
 
+# set up trap for termination signals
+trap "echo TERM; exit 1" SIGTERM SIGINT
+
 # Wait for the user to signal they are done
 until [ -f "$USER_SIGNAL_FILE_COMPLETE" ] || [ -f "$USER_SIGNAL_FILE_FAILED" ]
 do

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,4 +1,4 @@
 image: ims-python-helper
     source: python
-    major: 2
-    minor: 15
+    major: 3
+    minor: 0


### PR DESCRIPTION
## Summary and Scope

This fixes a problem with the wrong ims python helper version and adds a trap to the remote entrypoint script to help cleanup on abnormal exit.

## Issues and Related PRs
* Resolves [CASMCMS-8923](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8923)

## Testing
### Tested on:
  * `Baldar`

### Test description:

Installed on machine and tested abnormal shutdowns to insure remote resources got cleaned up correctly.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated

