### PR TITLE
CASMTRIAGE-6885 - fix etc/resolv.conf resolution for broken symlinks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.1] - 2024-04-12
+### Changed
+- CASMTRIAGE-6885 - fix etc/resolv.conf resolution when it is a broken symlink.
+
 ## [2.13.0] - 2024-03-01
 ### Added
 - CASMCMS-8821 - add support for remote build jobs.


### PR DESCRIPTION
## Summary and Scope

If the /etc/resolv.conf file that existed in the original image was a broken symbolic link, the process of saving off the original and restoring it at the end of the operation failed. Now it checked directly for a symbolic link and also moves that regardless of if the link is broken or valid.

I also discovered some issues with the complete/failed flag files so those are now straightened out as well.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6885](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6885)

## Testing
### Tested on:
  * `Tyr`

### Test description:

I installed the new test version of the image on Tyr and ran all combinations of remote and local x86 and aarch64 customize jobs, insuring that the resolv.conf file was correctly handled and the failed/complete flags behaved as they are supposed to.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a moderate risk change, but required for the customize jobs to function correctly.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

