### PR TITLE
CASMCMS-9040 - change permissions on image config files after recipe build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9040 - change permissions on image config files after recipe build.
+
 ## [2.13.2] - 2024-07-25
 ### Dependencies
 - Resolve CVES:

--- a/scripts/package_and_upload.sh
+++ b/scripts/package_and_upload.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -75,6 +75,22 @@ check_image_artifact_exists() {
 
 check_image_artifact_exists "$IMAGE_ROOT_DIR/boot/$KERNEL_FILENAME"
 check_image_artifact_exists "$IMAGE_ROOT_DIR/boot/$INITRD_FILENAME"
+
+# Change ownership and permissions on /image dir if it exists.
+#  This dir contains config files that may have sensative information
+#  in them and should only be readable by root.
+if [[ -d ${IMAGE_ROOT_DIR}/image ]]; then
+  # change read/write permissions of dir to root only
+  chown root ${IMAGE_ROOT_DIR}/image
+  chmod 700 ${IMAGE_ROOT_DIR}/image
+
+  # change files in the dir to root ownership and only rw for root
+  chown root ${IMAGE_ROOT_DIR}/image/*
+  chmod 600 ${IMAGE_ROOT_DIR}/image/*
+
+  # change the .sh file to rwx for root
+  chmod 700 ${IMAGE_ROOT_DIR}/image/*.sh
+fi
 
 # Make the squashfs formatted archive
 time mksquashfs "$IMAGE_ROOT_DIR" "$IMAGE_ROOT_PARENT/$IMAGE_ROOT_ARCHIVE_NAME.sqsh"


### PR DESCRIPTION
## Summary and Scope

When recipes are built with kiwi-ng, some of the config files are built into the resulting image with global read permissions. There are times these files contain sensitive information. This change makes the directory and the files only accessible by the root user.

## Issues and Related PRs

* Resolves [CASMCMS-9040](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9040)

## Testing
### Tested on:
  * `Tyr`

### Test description:

Built the barebones recipe on Tyr with the installed 1.6.0 system. I verified that the config files are present in the resulting image and are globally readable. I updated the ims-utils image and rebuilt the image. This time I was able to verify that the files still exist, but both the directory and file permissions are set in such a way that only the root user can see them.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change. If the files are present they have the permissions modified. If they don't exist nothing happens.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

