### PR TITLE
CASMCMS-9037 - remove unused ssh features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## Fixed
 - CASMCMS-9226 - fix mis-spelling.
+- CASMCMS-9037 - remove parts of openssh that are not being used for security.
 
 ## [2.14.0] - 2024-08-29
 ### Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apk add --upgrade --no-cache apk-tools \
             python3-dev \
             libc-dev \
             podman \
-            openssh \
+            openssh-client \
             bash \
         && apk -U upgrade --no-cache \
         &&  rm -rf \


### PR DESCRIPTION
## Summary and Scope

To help future CVE issues, only install the parts of openssh that we use, not the entire package.

## Issues and Related PRs
* Resolves [CASMCMS-9037](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9037)

## Testing
### Tested on:
  * `Wasp`

### Test description:

Ran through the entire range of workflows that use these scripts. Everything ran successfully with no errors in the log output.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

