### PR TITLE
CASMCMS-9282: Bump Alpine version from 3.15 to 3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.0] - 2025-02-13
+### Dependencies
+- CASMCMS-9282: Bump Alpine version from 3.15 to 3.21, because 3.15 no longer receives security patches
+
 ## [2.15.0] - 2024-12-10
 ## Fixed
 - CASMCMS-9226 - fix mis-spelling.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 # Cray Image Management Service image build environment utilities Dockerfile
 #
 
-FROM artifactory.algol60.net/docker.io/library/alpine:3.15 as base
+FROM artifactory.algol60.net/docker.io/library/alpine:3.21 as base
 
 # Add utilities that are required for this command
 WORKDIR /


### PR DESCRIPTION
Alpine 3.15 no longer receives security patches.

I tested this on wasp and verified that it works.