### PR TITLE
CASMTRIAGE-7899: Bump dependency versions to work with Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.1] - 2025-02-27
+### Dependencies
+- CASMTRIAGE-7899: Bump dependency versions to work with Python 3.12
+
 ## [2.16.0] - 2025-02-13
 ### Dependencies
 - CASMCMS-9282: Bump Alpine version from 3.15 to 3.21, because 3.15 no longer receives security patches

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,12 +1,12 @@
-boto3==1.12.49
-botocore==1.15.49
+boto3==1.36.2
+botocore==1.36.2
 cachetools==3.0.0
 certifi==2023.7.22
 chardet==3.0.4
 docutils==0.14
 google-auth==1.6.3
 idna==2.8
-ims-python-helper>=3.0,<3.1
+ims-python-helper>=3.1,<3.2
 Jinja2==2.10.3
 jmespath==0.9.5
 # CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
@@ -17,11 +17,11 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 python-dateutil==2.8.2
 PyYAML==6.0.1
-requests==2.23.0
+requests==2.27.1
 requests-oauthlib==1.0.0
 rsa==4.7.2
-s3transfer==0.3.7
+s3transfer==0.11.1
 setuptools>=70.0
-six==1.15.0
-urllib3==1.25.11
+six==1.17.0
+urllib3==1.26.18
 websocket-client==0.54.0


### PR DESCRIPTION
On wasp, IMS image customization sessions were failing with a Python stacktrace. Investigating, it appears that some of the pinned Python modules were unhappy with the upgrade to Python 3.12 (that came along as a consequence of updating the Alpine version). This PR placates it. I tested it on wasp and confirms that it corrects the issue.

Before:
```
+ python3 -m ims_python_helper image set_job_status 9e7cd1d2-a8ba-400b-b916-d7ef542f9751 error
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
Error: Downloading image return_code = 1
Warning: Could not set job status for job 9e7cd1d2-a8ba-400b-b916-d7ef542f9751 to error
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/scripts/venv/lib/python3.12/site-packages/ims_python_helper/__init__.py", line 48, in <module>
    import boto3  # noqa: E402
    ^^^^^^^^^^^^
  File "/scripts/venv/lib/python3.12/site-packages/boto3/__init__.py", line 16, in <module>
    from boto3.session import Session
  File "/scripts/venv/lib/python3.12/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/scripts/venv/lib/python3.12/site-packages/botocore/session.py", line 28, in <module>
    import botocore.configloader
  File "/scripts/venv/lib/python3.12/site-packages/botocore/configloader.py", line 19, in <module>
    from botocore.compat import six
  File "/scripts/venv/lib/python3.12/site-packages/botocore/compat.py", line 26, in <module>
    from dateutil.tz import tzlocal
  File "/scripts/venv/lib/python3.12/site-packages/dateutil/tz/__init__.py", line 2, in <module>
    from .tz import *
  File "/scripts/venv/lib/python3.12/site-packages/dateutil/tz/tz.py", line 21, in <module>
    from six.moves import _thread
ModuleNotFoundError: No module named 'six.moves'
```

After:
```
+ python3 /scripts/fetch.py --image True /mnt/image 'http://rgw-vip.nmn/boot-images/85c0550b-6477-4340-97ff-c04fe6d74ef3/rootfs?AWSAccessKeyId=0R74LJ2HIHXYK00MJX09&Signature=MCAlCXyOz3GxKqzbZ1KrEBpVLEw%3D&Expires=1741121634'
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:IMS_JOB_ID=3b439adc-5cbb-4e6c-9df4-07c4bd376d85
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Setting job status to 'fetching_image'.
INFO:ims_python_helper:image_set_job_status: {{ims_job_id: 3b439adc-5cbb-4e6c-9df4-07c4bd376d85, job_status: fetching_image}}
INFO:ims_python_helper:PATCH https://api-gw-service-nmn.local/apis/ims/jobs/3b439adc-5cbb-4e6c-9df4-07c4bd376d85 status=fetching_image
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Fetching image http://rgw-vip.nmn/boot-images/85c0550b-6477-4340-97ff-c04fe6d74ef3/rootfs?AWSAccessKeyId=0R74LJ2HIHXYK00MJX09&Signature=MCAlCXyOz3GxKqzbZ1KrEBpVLEw%3D&Expires=1741121634
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Saving file as '/mnt/image/image.sqsh'
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:File download complete.
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Verifying md5sum of the downloaded file.
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Successfully verified the md5sum of the downloaded file.
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Deleting signal files
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Uncompressing image into /mnt/image
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Deleting compressed image /mnt/image/image.sqsh
INFO:/scripts/venv/lib/python3.12/site-packages/ims_python_helper/fetch.py:Done
```