### PR TITLE
CASMTRIAGE-7899 - changes for alpine base image upgrade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.2] - 2025-03-04
+### Dependencies
+- CASMTRIAGE-7899: Update installed packages to make rpmbuild work.
+
 ## [2.16.1] - 2025-02-27
 ### Dependencies
 - CASMTRIAGE-7899: Bump dependency versions to work with Python 3.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ RUN apk add --upgrade --no-cache apk-tools \
             podman \
             openssh-client \
             bash \
+            findutils \
+            grep \
         && apk -U upgrade --no-cache \
         &&  rm -rf \
            /var/cache/apk/* \
@@ -52,6 +54,11 @@ RUN apk add --upgrade --no-cache apk-tools \
         && mkdir -p \
            /scripts \
            /config
+
+# There is a problem with the script brp-remove-la-files in alpine where
+#  it uses the wrong 'force' option for the rm installed here. Modify
+#  the script so the rpmbuild command will work in build-ca-rpm
+RUN sed -i 's/--force/-f/g' /usr/lib/rpm/brp-remove-la-files
 
 ENV VIRTUAL_ENV=/scripts/venv
 RUN python3 -m venv $VIRTUAL_ENV


### PR DESCRIPTION
## Summary and Scope

The upgraded version of alpine has changed the utilities and what options they use. I was able to upgrade a couple of the utilities, and I had to change a script in the rpmbuild install, but now building the ca-certs rpm works correctly in the recipe build path.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7899](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7899)

## Testing
### Tested on:
  * `Wasp`

### Test description:

I installed the new ims-utils binary and configured the create and customize jobs to use it. I then ran through building a recipe and customizing an image. I verified that all 'init' steps work correctly now.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

