### PR TITLE
CASMTRIAGE-8161: setting up certs failing with `update-ca-certificates: command not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.3] - 2025-05-01
+### Fixed
+- CASMTRIAGE-8161: setting up certs failing with `update-ca-certificates: command not found`
+
 ## [2.16.2] - 2025-03-04
 ### Dependencies
 - CASMTRIAGE-7899: Update installed packages to make rpmbuild work.

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apk add --upgrade --no-cache apk-tools \
             findutils \
             grep \
             ca-certificates \
+            fuse-overlayfs \
         && apk -U upgrade --no-cache \
         &&  rm -rf \
            /var/cache/apk/* \
@@ -60,6 +61,8 @@ RUN apk add --upgrade --no-cache apk-tools \
 #  it uses the wrong 'force' option for the rm installed here. Modify
 #  the script so the rpmbuild command will work in build-ca-rpm
 RUN sed -i 's/--force/-f/g' /usr/lib/rpm/brp-remove-la-files
+# To resolve issue overlay is not supported over overlayfs
+RUN sed -i 's/#mount_program/mount_program/' /etc/containers/storage.conf
 
 ENV VIRTUAL_ENV=/scripts/venv
 RUN python3 -m venv $VIRTUAL_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apk add --upgrade --no-cache apk-tools \
 #  it uses the wrong 'force' option for the rm installed here. Modify
 #  the script so the rpmbuild command will work in build-ca-rpm
 RUN sed -i 's/--force/-f/g' /usr/lib/rpm/brp-remove-la-files
-# To resolve issue overlay is not supported over overlayfs
+# To resolve issue overlay is not supported over overlayfs CASMTRIAGE-8161
 RUN sed -i 's/#mount_program/mount_program/' /etc/containers/storage.conf
 
 ENV VIRTUAL_ENV=/scripts/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN apk add --upgrade --no-cache apk-tools \
             bash \
             findutils \
             grep \
+            ca-certificates \
         && apk -U upgrade --no-cache \
         &&  rm -rf \
            /var/cache/apk/* \


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

CASMTRIAGE-8161: setting up certs failing with `update-ca-certificates: command not found

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

Tested in wasp.

Here is prepare conatiner log

```
+ fail_if_error 'Downloading image'
+ local retVal=0
+ [[ 0 -ne 0 ]]
+ [[ -n x3000c0s10b2n0 ]]
+ prep_remote_build
+ mkdir -p /root/.ssh
+ cp /etc/cray/remote-keys/id_ecdsa /root/.ssh
+ chmod 600 /root/.ssh/id_ecdsa
+ ssh-keygen -y -f /root/.ssh/id_ecdsa
+ echo 'Configuring remote job on host: x3000c0s10b2n0'
Configuring remote job on host: x3000c0s10b2n0
+ PODMAN_ARCH=linux/amd64
+ '[' x86_64 == aarch64 ']'
+ ssh -o StrictHostKeyChecking=no root@x3000c0s10b2n0 'mkdir -p /tmp/ims_d7228259-646b-4299-91ca-a40f02903f6c/'
Warning: Permanently added 'x3000c0s10b2n0' (ED25519) to the list of known hosts.
+ echo 'setting up certs...'
+ CA_CERT=/etc/cray/ca/certificate_authority.crt
setting up certs...
+ [[ -e /etc/cray/ca/certificate_authority.crt ]]
+ cp /etc/cray/ca/certificate_authority.crt /usr/local/share/ca-certificates
+ update-ca-certificates
WARNING: ca-cert-certificate_authority.pem does not contain exactly one certificate or CRL: skipping
+ RC=0
+ [[ ! -n 0 ]]
+ echo 'cat <<EOF'
+ cat Dockerfile.remote
+ sh
+ echo EOF
+ podman build --platform linux/amd64 -t ims-remote-d7228259-646b-4299-91ca-a40f02903f6c:1.0.0 .
STEP 1/14: FROM registry.local/artifactory.algol60.net/csm-docker/stable/cray-ims-sshd:1.12.0 AS base
Trying to pull registry.local/artifactory.algol60.net/csm-docker/stable/cray-ims-sshd:1.12.0...
Getting image source signatures
Copying blob sha256:2e2ec9085dd5202011750628036d4777842ed740233af058a7f0a39cef65c3a5
Copying blob sha256:da8227b00de90a9487adeba9925bbdef55ec64b62ca4215ffd5600ff6199eba3
Copying blob sha256:c7d36f7a54aa496635a75558da233a8ebeb9a3aef91e3ecaca8f11f842185777
Copying blob sha256:876b90fe2ee57dd53b0725e8b6fbbd6c3bb4da77cb1f170524b65a2c3ff05362
Copying blob sha256:8459306a02e838c5a202c82601d330d259f746be9386c3d600c980aa71369ef8
Copying blob sha256:95791c3a3b3a046848540c299465f9231b17f7dfc63001cf3eb0a95600856e86
Copying blob sha256:255f1b813450d897d2c597b3de5eae351043e82ae1aaf2ca66bec61bbf06d84f
Copying config sha256:34159e83757852603780eb3ae9c1849261c079ef23fbf419052a2d33b7868393
Writing manifest to image destination
STEP 2/14: COPY /scripts/remote_customize_entrypoint.sh /entrypoint.sh
--> 0311e80c0466
STEP 3/14: COPY /etc/cray/ca/certificate_authority.crt /etc/cray/ca/certificate_authority.crt
--> f39b96f2051b
STEP 4/14: COPY /etc/admin-client-auth /etc/admin-client-auth
--> d93f55b912fb
STEP 5/14: COPY /mnt/image/image.sqsh /data/
--> a15c694c2227
STEP 6/14: COPY /config/sshd_config /etc/cray/ims/sshd_config
--> 3fc03d951d46
STEP 7/14: COPY /root/.ssh/id_ecdsa.pub /etc/cray/ims/authorized_keys
--> 68e1727b58e7
STEP 8/14: ENV OAUTH_CONFIG_DIR=/etc/admin-client-auth
--> 3750994cf5bc
STEP 9/14: ENV BUILD_ARCH=x86_64
--> 01ee02b68583
STEP 10/14: ENV IMS_JOB_ID=d7228259-646b-4299-91ca-a40f02903f6c
--> c105fc3fb933
STEP 11/14: ENV IMAGE_ROOT_PARENT=/mnt/image
--> 1cc8167c9d0a
STEP 12/14: ENV SSH_JAIL=True
--> d6d5aeef8cf3
STEP 13/14: ENV JOB_ENABLE_DKMS=True
--> 8e5944114594
STEP 14/14: ENTRYPOINT ["/entrypoint.sh"]
COMMIT ims-remote-d7228259-646b-4299-91ca-a40f02903f6c:1.0.0
--> 74329cbf9a6f
Successfully tagged localhost/ims-remote-d7228259-646b-4299-91ca-a40f02903f6c:1.0.0
74329cbf9a6f2555bd6d40dde06b6b1a6c81a1fd9ba7dceff21b1247566ba557
+ RC=0
+ [[ ! -n 0 ]]
+ podman save ims-remote-d7228259-646b-4299-91ca-a40f02903f6c:1.0.0
+ ssh -o StrictHostKeyChecking=no root@x3000c0s10b2n0 podman load
Getting image source signatures
Copying blob sha256:3f1eeb60b03aaa92fde101b3cc229d995a1fe56f0778b499f360297d41cb91b8
Copying blob sha256:7b9db404a7a9c344f0b6f0a02fa931ea2fe8ac54186f77e36910080647296a97
Copying blob sha256:18dd70553a20b06c8d5bf8caef5f8a86ec7b04def3f97c44b7735556a661daa9
Copying blob sha256:b1fdcf6d76aed29daa6ca22013010ae08abb3a1053bdca981c9c559a8c332877
Copying blob sha256:9691d2ddbccfcb579bbe4db0c0b3244e7302d1f471f5be27355c0153f97614d1
Copying blob sha256:c8fc08132d000ac07103996b54be612da08d5a3a4c7127eac636ecddc078dc11
Copying blob sha256:2244ca4b1427adf4834dfa4585e523ce023492280cc17c8055fa02ea8dedea74
Copying blob sha256:e5408ea86b434cf11e57d189b0a6a7ebd7d273d1bdfeec7d7432664dbe0cecb1
Copying blob sha256:5b831e83b2d45b082aba25c3b4b78da0004b04dfb1e7f86d5297470564bc504f
Copying blob sha256:f4df8d2335ce3b2fd8bf16f67bee9eac0397bf735b6df6677e1d083cacd98a6f
Copying blob sha256:9755ed1a92b3b2b470ee2637a210a107151a1db9d638b4e1a8672ea7f26cc84b
Copying blob sha256:d582287ea8ec137e811d11618fda731c19ce1c8626bcb3b22508961c24fcc81f
Copying blob sha256:b2474951214017dae403987d5594e14278246f13b61f9e9b152325f0576cdb0f
Copying config sha256:74329cbf9a6f2555bd6d40dde06b6b1a6c81a1fd9ba7dceff21b1247566ba557
Writing manifest to image destination
Loaded image: localhost/ims-remote-d7228259-646b-4299-91ca-a40f02903f6c:1.0.0
+ RC=0
+ [[ 0 -ne 0 ]]
+ '[' true ']'
+ find_free_port
+ re='^(.*)0.0.0.0:(.*)$'
+ allPorts=()
+ read i
++ ssh -o StrictHostKeyChecking=no root@x3000c0s10b2n0 'podman port -a'
+ IFS='
'
+ allPorts=($(sort <<< "${allPorts[*]}"))
++ sort
+ unset IFS
+ REMOTE_PORT=2022
+ ssh -o StrictHostKeyChecking=no root@x3000c0s10b2n0 'podman run -p 2022:22 --name ims-d7228259-646b-4299-91ca-a40f02903f6c --privileged --detach ims-remote-d7228259-646b-4299-91ca-a40f02903f6c:1.0.0'
2df4e2f402c69456c5b9242cf27de766187837729d4c3b9640a148b20ceef80d
+ RC=0
+ [[ RC -eq 255 ]]
+ [[ RC -eq 126 ]]
+ [[ RC -ne 0 ]]
+ break
+ echo 2022
```

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

