### PR TITLE
CASMCMS-8939 - allow sftp and scp to work on remote builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-8939 - better port forwarding for remote jobs.
 
 ## [2.16.3] - 2025-05-01
 ### Fixed

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,7 +32,7 @@ COPY /etc/cray/ca/certificate_authority.crt /etc/cray/ca/certificate_authority.c
 COPY /etc/admin-client-auth /etc/admin-client-auth
 COPY /mnt/image/image.sqsh /data/
 COPY /config/sshd_config /etc/cray/ims/sshd_config
-COPY /root/.ssh/id_ecdsa.pub /etc/cray/ims/authorized_keys
+COPY /root/remote_authorized_keys /etc/cray/ims/authorized_keys
 
 # Copy in env vars needed for the remote job run
 ENV OAUTH_CONFIG_DIR=$OAUTH_CONFIG_DIR

--- a/scripts/prep-env.sh
+++ b/scripts/prep-env.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -96,6 +96,11 @@ function prep_remote_build() {
       exit 1
     fi
 
+    # Add user ssh public key to the remote node access public key
+    # NOTE: /etc/cray/ims/authorized_keys is mounted from the ims job config map
+    # NOTE: used in Dockerfile.remote to set up the ssh server on the remote container
+    cat ~/.ssh/id_ecdsa.pub /etc/cray/authorized_keys >> /root/remote_authorized_keys
+
     # Apply env vars to dockerfile template
     (echo "cat <<EOF" ; cat Dockerfile.remote ; echo EOF ) | sh > Dockerfile
 
@@ -115,7 +120,7 @@ function prep_remote_build() {
       exit 1
     fi
 
-    # There is a faint possiblity another job will start between querying for
+    # There is a faint possibility another job will start between querying for
     # open ports and starting the remote container. Add a while loop to keep
     # trying when the port is in use.
     while [ true ]; do
@@ -123,7 +128,7 @@ function prep_remote_build() {
       find_free_port
 
       # start the image on the remote node
-      # NOTE: this will just run indefinately until a complete flag is created
+      # NOTE: this will just run indefinitely until a complete flag is created
       ssh -o StrictHostKeyChecking=no root@${REMOTE_BUILD_NODE} "podman run -p ${REMOTE_PORT}:22 --name ims-${IMS_JOB_ID} --privileged --detach ims-remote-${IMS_JOB_ID}:1.0.0"
 
       # if the ssh command failed

--- a/scripts/remote_customize_entrypoint.sh
+++ b/scripts/remote_customize_entrypoint.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -154,7 +154,7 @@ fi
 mkdir -p ~/.ssh
 ssh-keygen -A
 
-# add env vars the incomming users need
+# add env vars the incoming users need
 echo "SetEnv IMS_JOB_ID=$IMS_JOB_ID IMS_ARCH=$BUILD_ARCH IMS_DKMS_ENABLED=$JOB_ENABLE_DKMS" >> $SSHD_CONFIG_FILE
 
 # Start the SSH server daemon


### PR DESCRIPTION
## Summary and Scope

Use port-forwarding via iptables to forward ssh connections to a remote build node rather than routing through an ssh server. This is much more straightforward and allows commands like scp and sftp to work as well as the basic ssh commands.

## Issues and Related PRs
* Resolves [CASMCMS-8939](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8939)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the new set of images and helm charts via loftsman and ran both manual and cfs image customization jobs. I verified that the jobs worked as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is low risk - it only applies to remote image customization jobs.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
