### PR TITLE
CASMCMS-8022, CASMCMS-9455: ims-python-helper & python packages updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- CASMCMS-9455: Updated ims-python-helper version to 3.2.x
+- CASMCMS-8022:  update python modules
+
+- Bumped dependency patch versions:
+| Package                | From      | To        |
+|------------------------|-----------|-----------|
+| `botocore`             | 1.36.2    | 1.36.26   |
+| `cachetools`           | 3.0.0     | 5.3.3     |
+| `certifi`              | 2023.7.22 | 2025.6.15 |
+| `chardet`              | 3.0.4     | 5.2.0     |
+| `docutils`             | 0.14      | 0.21      |
+| `google-auth`          | 1.6.3     | 2.29.0    |
+| `idna`                 | 2.8       | 3.10.0    |
+| `Jinja2`               | 2.10.3    | 3.1.6     |
+| `jmespath`             | 0.9.5     | 1.0.1     |
+| `MarkupSafe`           | <2.1.0    | 2.1.5     |
+| `oauthlib`             | 2.1.0     | 3.2.2     |
+| `pyasn1`               | 0.4.8     | 0.6.1     |
+| `pyasn1-modules`       | 0.2.8     | 0.4.0     |
+| `requests`             | 2.27.1    | 2.32.4    |
+| `requests-oauthlib`    | 1.0.0     | 2.0.0     |
+| `rsa`                  | 4.7.2     | 4.9       |
+| `s3transfer`           | 0.11.1    | 0.11.3    |
+| `urllib3`              | 1.26.18   | 2.4.0     |
+| `websocket-client`     | 0.54.0    | 1.8.0     |
+
 ## [2.17.0] - 2025-06-10
 ### Changed
 - CASMCMS-8939 - better port forwarding for remote jobs.

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,27 +1,27 @@
 boto3==1.36.2
-botocore==1.36.2
-cachetools==3.0.0
-certifi==2023.7.22
-chardet==3.0.4
-docutils==0.14
-google-auth==1.6.3
-idna==2.8
-ims-python-helper>=3.1,<3.2
-Jinja2==2.10.3
-jmespath==0.9.5
-# CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
+botocore==1.36.26 # boto3 1.36.2 requires 1.36.26
+cachetools==5.3.3
+certifi==2025.6.15
+chardet==5.2.0
+docutils==0.21.0
+google-auth==2.29.0
+idna==3.10.0
+ims-python-helper>=3.2,<3.3
+Jinja2==3.1.6
+jmespath==1.0.1
+# CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatibility
 kubernetes>=24.2,<24.3
-MarkupSafe<2.1.0
-oauthlib==2.1.0
-pyasn1==0.4.8
-pyasn1-modules==0.2.8
+MarkupSafe==2.1.5
+oauthlib==3.2.2
+pyasn1==0.6.1 # matching ims
+pyasn1-modules==0.4.0
 python-dateutil==2.8.2
 PyYAML==6.0.1
-requests==2.27.1
-requests-oauthlib==1.0.0
-rsa==4.7.2
-s3transfer==0.11.1
+requests==2.32.4
+requests-oauthlib==2.0.0
+rsa==4.9
+s3transfer==0.11.3 # botocore 1.36.2 requires 0.11.3
 setuptools>=70.0
-six==1.17.0
-urllib3==1.26.18
-websocket-client==0.54.0
+six==1.17.0 # botocore 1.36.2 requires 1.17.0
+urllib3==2.4.0
+websocket-client==1.8.0


### PR DESCRIPTION
## Summary and Scope
CASMCMS-8022, CASMCMS-9455: ims-python-helper & python packages updated

## Testing
- This was tested on `mug` and `surtur`
- Tested IMS image creation from recipe
- Tested IMS image customization

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

