### PR TITLE
CASMCMS-9510: Updated ims-python-helper version to 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 - Update `kubernetes` module to match CSM Kubernetes version
+- CASMCMS-9510: Updated ims-python-helper version to 3.3.x
 
 ## [2.18.0] - 2025-06-17
 ### Dependencies

--- a/constraints.txt
+++ b/constraints.txt
@@ -6,7 +6,7 @@ chardet==5.2.0
 docutils==0.21.0
 google-auth==2.29.0
 idna==3.10.0
-ims-python-helper>=3.2,<3.3
+ims-python-helper>=3.3,<3.4
 Jinja2==3.1.6
 jmespath==1.0.1
 # CSM 1.7 moved to Kubernetes 1.32, so use client v32.x to ensure compatibility


### PR DESCRIPTION
## Summary and Scope
CASMCMS-9510: Updated ims-python-helper version to 3.3.x


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

