### PR TITLE
Develop->master CASMCMS-9510: Updated ims-python-helper version to 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- Update `kubernetes` module to match CSM Kubernetes version
+
 ## [2.18.0] - 2025-06-17
 ### Dependencies
 - CASMCMS-9455: Updated ims-python-helper version to 3.2.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.0] - 2025-08-19
 ### Dependencies
 - Update `kubernetes` module to match CSM Kubernetes version
 - CASMCMS-9510: Updated ims-python-helper version to 3.3.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.18.0] - 2025-06-17
 ### Dependencies
 - CASMCMS-9455: Updated ims-python-helper version to 3.2.x
 - CASMCMS-8022:  update python modules

--- a/constraints.txt
+++ b/constraints.txt
@@ -9,14 +9,14 @@ idna==3.10.0
 ims-python-helper>=3.2,<3.3
 Jinja2==3.1.6
 jmespath==1.0.1
-# CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatibility
-kubernetes>=24.2,<24.3
+# CSM 1.7 moved to Kubernetes 1.32, so use client v32.x to ensure compatibility
+kubernetes>=32.0,<32.1
 MarkupSafe==2.1.5
 oauthlib==3.2.2
 pyasn1==0.6.1 # matching ims
 pyasn1-modules==0.4.0
 python-dateutil==2.8.2
-PyYAML==6.0.1
+PyYAML>=6.0.2,<6.1
 requests==2.32.4
 requests-oauthlib==2.0.0
 rsa==4.9


### PR DESCRIPTION
## Summary and Scope
- Update `kubernetes` module to match CSM Kubernetes version
- CASMCMS-9510: Updated ims-python-helper version to 3.3.x

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

